### PR TITLE
Update to api.js - added GetLatest endpoint

### DIFF
--- a/lib/api.js
+++ b/lib/api.js
@@ -112,6 +112,10 @@ module.exports = [
         availables: ["list", "get", "create", "update", "delete"]
       },
       {
+        name: "Transaction/GetLatest",
+        availables: ["list"]
+      },
+      {
         name: "Transaction/Validate",
         availables: ["create"]
       },


### PR DESCRIPTION
added new v4 api endpoint -- GetLatest

eposnow Implementation Notes
Use this method to get all transactions ordered by date descending

Supports pagination via page parameter. 200 response items per page.
Not providing page will return items for page 1.
Response Class (Status 200)